### PR TITLE
fix: Fixed import statement for Initializable.sol  - fix

### DIFF
--- a/contracts/BaseApp.sol
+++ b/contracts/BaseApp.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import "./storage/CmnStorage.sol";
 import "./interface/ICrossChain.sol";


### PR DESCRIPTION
fix: The URL for this import is not working when you use REMIX

This fixes it

### Description

Well, this is simple, the url seems to be wrong or assumes the openzepellin sdk is installed in the same repo.

### Rationale

Remix is throwing an error, so it must be fixed to continue.
