### PR TITLE
fix wrong import path for forge build to work

### DIFF
--- a/contracts/examples/ebook-shop.sol
+++ b/contracts/examples/ebook-shop.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import "@bnb-chain/greenfield-contracts/contracts/interface/IERC721Nontransferable.sol";
-import "@bnb-chain/greenfield-contracts/contracts/interface/IERC1155Nontransferable.sol";
+import "@bnb-chain/greenfield-contracts/contracts/interface/IERC721NonTransferable.sol";
+import "@bnb-chain/greenfield-contracts/contracts/interface/IERC1155NonTransferable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
 import "../BucketApp.sol";


### PR DESCRIPTION
### Description

changed ..Nontransferable.. to ..NonTransferable..  in the import path 

### Rationale

Forge build was failing 

### Example
Before change:
```bash
dzcodes@LAPTOP-DMGBA44V:~/hack/solidity/greenfield-contracts-sdk$ forge clean
dzcodes@LAPTOP-DMGBA44V:~/hack/solidity/greenfield-contracts-sdk$ forge build
[⠃] Compiling...2024-03-28T21:52:13.336647Z ERROR foundry_compilers::artifacts: error="/home/dzcodes/hack/solidity/greenfield-contracts-sdk/node_modules/@bnb-chain/greenfield-contracts/interface/IERC721Nontransferable.sol": No such file or directory (os error 2)
[⠊] Compiling...
Error: 
failed to resolve file: "/home/dzcodes/hack/solidity/greenfield-contracts-sdk/node_modules/@bnb-chain/greenfield-contracts/interface/IERC721Nontransferable.sol": No such file or directory (os error 2); check configured remappings
        --> /home/dzcodes/hack/solidity/greenfield-contracts-sdk/contracts/examples/ebook-shop.sol
        @bnb-chain/greenfield-contracts/contracts/interface/IERC721Nontransferable.sol
```
After change:
```bash
dzcodes@LAPTOP-DMGBA44V:~/hack/solidity/greenfield-contracts-sdk$ forge clean
dzcodes@LAPTOP-DMGBA44V:~/hack/solidity/greenfield-contracts-sdk$ forge build
[⠊] Compiling...
[⠢] Compiling 35 files with 0.8.19
[⠆] Solc 0.8.19 finished in 1.08s
Compiler run successful!
```


### Changes

Notable changes:
* import path changed to @bnb-chain/greenfield-contracts/contracts/interface/IERC721NonTransferable.sol
* import path changed to @bnb-chain/greenfield-contracts/contracts/interface/IERC1155NonTransferable.sol